### PR TITLE
[#43] Dwustronna komunikacja

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -9,7 +9,7 @@ Swagger api documentation can be accessed on url `/swagger-ui.html`
 
 ## Session handling quick view
 #### Creating, joining and closing:
-* Creating session: /session/create -> returns passcode (active session created in DB)
+* Creating session: /session/create -> returns sessions ID and passcode (active session created in DB)
 * Connecting to session: /session/connect -> returns session ID and session title (used to find session websocket endpoint when sending a message - /app/session/{sessionId}/send)
 * Closing session: /session/close -> session with given ID is now closed (still in DB)
 #### Websocket communication in one session:

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,7 +9,7 @@ Swagger api documentation can be accessed on url `/swagger-ui.html`
 
 ## Session handling quick view
 #### Creating, joining and closing:
-* Creating session: /session/create -> returns sessions ID and passcode (active session created in DB)
+* Creating session: /session/create -> returns session ID and passcode (active session created in DB)
 * Connecting to session: /session/connect -> returns session ID and session title (used to find session websocket endpoint when sending a message - /app/session/{sessionId}/send)
 * Closing session: /session/close -> session with given ID is now closed (still in DB)
 #### Websocket communication in one session:

--- a/backend/src/main/java/c/team/account/UserAccountController.java
+++ b/backend/src/main/java/c/team/account/UserAccountController.java
@@ -1,5 +1,7 @@
 package c.team.account;
 
+import c.team.account.exception.DuplicateUsernameException;
+import c.team.account.exception.UserNotFoundException;
 import c.team.account.model.LoginRequest;
 import c.team.account.model.LoginResponse;
 import c.team.account.model.RegisterAccountRequest;
@@ -9,10 +11,8 @@ import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -35,5 +35,15 @@ public class UserAccountController {
         UUID token = tokenService.generateTokenForAccount(userAccount);
         LoginResponse loginResponse = new LoginResponse(token);
         return ResponseEntity.ok(loginResponse);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public final ResponseEntity<Error> handleException(UsernameNotFoundException ex){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+    @ExceptionHandler(DuplicateUsernameException.class)
+    public final ResponseEntity<Error> handleException(DuplicateUsernameException ex){
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }
 }

--- a/backend/src/main/java/c/team/account/exception/DuplicateUsernameException.java
+++ b/backend/src/main/java/c/team/account/exception/DuplicateUsernameException.java
@@ -1,7 +1,4 @@
 package c.team.account.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 public class DuplicateUsernameException extends RuntimeException {
 }

--- a/backend/src/main/java/c/team/account/exception/DuplicateUsernameException.java
+++ b/backend/src/main/java/c/team/account/exception/DuplicateUsernameException.java
@@ -3,6 +3,5 @@ package c.team.account.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(HttpStatus.CONFLICT)
 public class DuplicateUsernameException extends RuntimeException {
 }

--- a/backend/src/main/java/c/team/account/exception/UserNotFoundException.java
+++ b/backend/src/main/java/c/team/account/exception/UserNotFoundException.java
@@ -1,4 +1,4 @@
 package c.team.account.exception;
 
-public class UserNotFoundException extends RuntimeException {
-}
+public class UserNotFoundException extends RuntimeException {   // Can be deleted, we're throwing different exception
+}                                                               // from Spring framework (in UserAccountService)

--- a/backend/src/main/java/c/team/message/model/Message.java
+++ b/backend/src/main/java/c/team/message/model/Message.java
@@ -7,8 +7,9 @@ import lombok.Data;
 @Builder
 public class Message {
     private String sender;
-    private String replyingTo;
+    private String replyMsgId;  // Id of msg when replying, if not replying than it's null
     private MessageType type;
     private String timestamp;
+    private String sessionId;
     private String content; // TODO:  Change to Content class when implementing quizzes, etc.
 }

--- a/backend/src/main/java/c/team/message/model/Message.java
+++ b/backend/src/main/java/c/team/message/model/Message.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 @Data
 @Builder
+
 public class Message {
+    private int id; // Unique in session, frontend sends empty
     private String sender;
-    private String replyMsgId;  // Id of msg when replying, if not replying than it's null
+    private int replyMsgId;  // Id of msg when replying, if not replying than it's -1
     private MessageType type;
     private String timestamp;
     private String sessionId;

--- a/backend/src/main/java/c/team/session/SessionService.java
+++ b/backend/src/main/java/c/team/session/SessionService.java
@@ -52,6 +52,7 @@ public class SessionService {
 
     public void addMessageToSessionLog(String sessionId, Message message){
         Session session = this.findBySessionId(sessionId);
+        message.setId(session.getLog().size());
         session.getLog().add(message);
         sessionRepository.save(session);
     }

--- a/backend/src/main/java/c/team/session/controller/SessionController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionController.java
@@ -21,6 +21,7 @@ public class SessionController {
     @SendTo("/topic/session/{sessionId}")
     public Message sendMessage(@DestinationVariable String sessionId, @Payload final Message message){
         sessionsService.addMessageToSessionLog(sessionId, message);
+        // Possibly some validation whether sender is in this session
         return message;
     }
 
@@ -28,7 +29,8 @@ public class SessionController {
     @SendTo("/topic/session/{sessionId}")
     public Message addParticipant(@DestinationVariable String sessionId, @Payload final Message message, SimpMessageHeaderAccessor headerAccessor){
         headerAccessor.getSessionAttributes().put("username", message.getSender());
-        // TODO: Add user to particular session
+        headerAccessor.getSessionAttributes().put("sessionId", message.getSessionId());
+        sessionsService.addGuestToSession(message.getSessionId(), message.getSender());
         return message;
     }
 }

--- a/backend/src/main/java/c/team/session/controller/SessionEventListener.java
+++ b/backend/src/main/java/c/team/session/controller/SessionEventListener.java
@@ -4,7 +4,6 @@ import c.team.session.SessionService;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
@@ -14,7 +13,6 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class SessionEventListener {
 
-    private SimpMessageSendingOperations sendingOperations;
     private SessionService sessionService;
 
     @EventListener

--- a/backend/src/main/java/c/team/session/controller/SessionEventListener.java
+++ b/backend/src/main/java/c/team/session/controller/SessionEventListener.java
@@ -1,9 +1,11 @@
 package c.team.session.controller;
 
+import c.team.session.SessionService;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
@@ -13,14 +15,18 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 public class SessionEventListener {
 
     private SimpMessageSendingOperations sendingOperations;
+    private SessionService sessionService;
 
     @EventListener
     public void handleParticipantConnect(final SessionConnectedEvent event) {
-        // Something to do after connecting to server
+        // Something to do after connecting to server, probably not needed
     }
 
     @EventListener
     public void handleParticipantDisconnect(final SessionDisconnectEvent event) {
-        // Something to do on disconnect to server
+        final StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        final String guestName = (String) headerAccessor.getSessionAttributes().get("username");
+        final String sessionId = (String) headerAccessor.getSessionAttributes().get("sessionId");
+        sessionService.removeGuestFromSession(sessionId, guestName);
     }
 }

--- a/backend/src/main/java/c/team/session/exception/SessionClosedException.java
+++ b/backend/src/main/java/c/team/session/exception/SessionClosedException.java
@@ -1,0 +1,8 @@
+package c.team.session.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.PRECONDITION_FAILED, reason = "Session is already closed")
+public class SessionClosedException extends RuntimeException{
+}

--- a/backend/src/main/java/c/team/session/model/Guest.java
+++ b/backend/src/main/java/c/team/session/model/Guest.java
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Data
 @Builder
 @Document
-public class Guest {
+public class Guest {    // Not sure how it behaves with hashset
     @Id
     private String id;
     private String username;

--- a/backend/src/main/java/c/team/session/model/Session.java
+++ b/backend/src/main/java/c/team/session/model/Session.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.Id;;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Data
@@ -20,4 +21,5 @@ public class Session {
     private UUID passcode;
     private boolean active;
     private List<Message> log;
+    private Set<Guest> guests;
 }

--- a/backend/src/main/java/c/team/session/model/SessionCreateResponse.java
+++ b/backend/src/main/java/c/team/session/model/SessionCreateResponse.java
@@ -1,0 +1,11 @@
+package c.team.session.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SessionCreateResponse {
+    String sessionId;
+    String passcode;
+}


### PR DESCRIPTION
Dwustronna komunikacja podczas sesji właściwie powinna być możliwa już wcześniej dzięki samym websocketom - natomiast potraktowałem to bardziej jako dwustronną komunikację między frontendem i backendem - wyjątki teraz poprawnie odwzorowują się na kod odpowiedzi HTTP, troszkę dopracowałem model wiadomości, dorzuciłem też rejestrowanie listy gości (bo w sumie to powinno być już wcześniej), już nie da się podłączać do zamkniętych sesji oraz stworzenie sesji zwraca teraz również jej id (aby dało się stworzyć websocket u prowadzące, który zakłada sesję). Trochę zrobiłem rzeczy off-top - to bardziej pasuje na hotfixy i dalej będę to robić w postaci takich branchy.