### PR TITLE
[#2] Guest approval

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -9,11 +9,21 @@ Swagger api documentation can be accessed on url `/swagger-ui.html`
 
 ## Session handling quick view
 #### Creating, joining and closing:
-* Creating session: /session/create -> returns session ID and passcode (active session created in DB)
-* Connecting to session: /session/connect -> returns session ID and session title (used to find session websocket endpoint when sending a message - /app/session/{sessionId}/send)
-* Closing session: /session/close -> session with given ID is now closed (still in DB)
+* **Creating session:** /session/create -> returns session ID, passcode and approval room ID - only if guests need to be approved (active session created in DB)
+  * If guests need to be approved - additional websockets need to be subscribed
+  * ***Guest:***
+    * **Sends request to:** /app/session/{sessionApprovalId}/guest-approval-request
+    * **Subscribes for response to:** /topic/session/{sessionApprovalId}/guest-approval-response/guest-{guestId}
+  * ***Room leader:***
+    * **Subscribes for request to:** /topic/session/{sessionApprovalId}/guest-approval-request
+    * **Sends response to user to:** /app/session/{sessionApprovalId}/guest-approval-response/{guestId} 
+    
+* **Connecting to session:** /session/connect -> returns session info - session ID/approval room ID, session title, 
+  guest ID and whether guests require approval (used to find session websocket endpoint when sending a message - 
+  /app/session/{sessionId}/send or where to ask for an approval for joining)
+* **Closing session:** /session/close -> session with given ID is now closed (still in DB)
 #### Websocket communication in one session:
-* Creating websocket: /session-handling (websocket connection address)
-* Subscribtion: /topic/session/{sessionId} (receiving all messages, requires getting session ID from connect request)
-* Sending message: /app/session/{sessionId}/send (requires getting session ID from connect request)
-* Registering as a new guest: /app/session/{sessionId}/new-user (potentially a welcoming message, requires getting session ID from connect request)
+* **Creating websocket:** /session-handling (websocket connection address)
+* **Subscribtion:** /topic/session/{sessionId} (receiving all messages, requires getting session ID from connect request)
+* **Sending message:** /app/session/{sessionId}/send (requires getting session ID from connect request)
+* **Registering as a new guest:** /app/session/{sessionId}/new-user (potentially a welcoming message, requires getting session ID from connect request)

--- a/backend/src/main/java/c/team/message/exception/InvalidMessageTypeException.java
+++ b/backend/src/main/java/c/team/message/exception/InvalidMessageTypeException.java
@@ -1,0 +1,4 @@
+package c.team.message.exception;
+
+public class InvalidMessageTypeException extends RuntimeException{
+}

--- a/backend/src/main/java/c/team/message/model/MessageType.java
+++ b/backend/src/main/java/c/team/message/model/MessageType.java
@@ -5,7 +5,8 @@ public enum MessageType {
     COMMENT,
     REPLY,
     CONNECT,
-    DISCONNECT
+    DISCONNECT,
+    GUEST_APPROVAL
     // QUIZ, different types of it
 
 }

--- a/backend/src/main/java/c/team/session/SessionService.java
+++ b/backend/src/main/java/c/team/session/SessionService.java
@@ -4,6 +4,7 @@ import c.team.account.UserAccountService;
 import c.team.account.model.UserAccount;
 import c.team.message.model.Message;
 import c.team.session.exception.SessionNotFoundException;
+import c.team.session.exception.SessionNotOwnedException;
 import c.team.session.model.Guest;
 import c.team.session.model.Session;
 import lombok.AllArgsConstructor;
@@ -47,8 +48,13 @@ public class SessionService {
         return session;
     }
 
-    public void closeSession(String sessionId){
+    public void closeSession(String sessionId, String leaderUsername){
+        UserAccount account = accountService.findByUsername(leaderUsername);
         Session session = this.findBySessionId(sessionId);
+
+        if (!account.getId().equals(session.getLeaderAccountId()))
+            throw new SessionNotOwnedException();
+
         session.setActive(false);
         sessionRepository.save(session);
         LOGGER.info("Closed session: " + sessionId);

--- a/backend/src/main/java/c/team/session/SessionService.java
+++ b/backend/src/main/java/c/team/session/SessionService.java
@@ -27,18 +27,22 @@ public class SessionService {
     private final SessionRepository sessionRepository;
     private final UserAccountService accountService;
 
-    public Session createSession(String leaderUsername, String title){
+    public Session createSession(String leaderUsername, String title, boolean guestApproval){
         UserAccount account = accountService.findByUsername(leaderUsername);
         Session session = Session.builder()
                 .leaderAccountId(account.getId())
                 .title(title)
                 .active(true)
                 .passcode(UUID.randomUUID())
+                .guestApproval(guestApproval)
                 .log(new ArrayList<>())
                 .guests(new HashSet<>())
                 .build();
 
-        UUID passcode = sessionRepository.save(session).getPasscode();
+        if (guestApproval)
+            session.setGuestApprovalRoomId(UUID.randomUUID());
+
+        sessionRepository.save(session);
         LOGGER.info("Opened session: " + session.getId());
         return session;
     }

--- a/backend/src/main/java/c/team/session/controller/SessionController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionController.java
@@ -1,15 +1,22 @@
 package c.team.session.controller;
 
+import c.team.message.exception.InvalidMessageTypeException;
 import c.team.message.model.Message;
 import c.team.session.SessionService;
+import c.team.session.exception.SessionNotFoundException;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Controller
 @AllArgsConstructor(onConstructor = @__(@Autowired))
@@ -32,5 +39,25 @@ public class SessionController {
         headerAccessor.getSessionAttributes().put("sessionId", message.getSessionId());
         sessionsService.addGuestToSession(message.getSessionId(), message.getSender());
         return message;
+    }
+
+    @MessageMapping("/session/{sessionApprovalId}/guest-approval-request")  // Here guest sends a request
+    @SendTo("/topic/session/{sessionApprovalId}/guest-approval-request")    // Here room leader subscribes for requests
+    public Message guestApprovalRequest(@DestinationVariable String sessionApprovalId, @Payload final Message message){
+        return message;
+    }
+
+    // Routed to endpoint for particular guest
+    @MessageMapping("/session/{sessionApprovalId}/guest-approval-response/{guestId}")       // Here room leader sends response
+    @SendTo("/topic/session/{sessionApprovalId}/guest-approval-response/guest-{guestId}")   // Here guest subscribes to listen for response
+    // Can be done with UserDestinationMessageHandler and @SentToUser but it's harder
+    public Message guestApprovalResponse(@DestinationVariable String sessionApprovalId, @DestinationVariable String guestId, @Payload final Message message){
+
+        return message;
+    }
+
+    @ExceptionHandler(InvalidMessageTypeException.class)
+    public final ResponseEntity<Error> handleException(InvalidMessageTypeException ex){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 }

--- a/backend/src/main/java/c/team/session/controller/SessionManagerController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionManagerController.java
@@ -22,7 +22,11 @@ public class SessionManagerController {
     @PostMapping("create")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<SessionCreateResponse> createSession(@RequestBody SessionCreateRequest request){
-        Session session = sessionsService.createSession(request.getUsername(), request.getSessionTitle());
+        Session session = sessionsService.createSession(
+                request.getUsername(),
+                request.getSessionTitle(),
+                request.isGuestApproval()
+        );
         SessionCreateResponse response = new SessionCreateResponse(session.getId(), session.getPasscode().toString());
         return ResponseEntity.ok(response);
     }
@@ -31,7 +35,13 @@ public class SessionManagerController {
     public ResponseEntity<GuestResponse> connectToSession(@RequestBody GuestRequest request){
         Session session = sessionsService.findByPasscode(UUID.fromString(request.getPasscode()));
         if(session.isActive()) {
-            GuestResponse response = new GuestResponse(session.getId(), session.getTitle());
+            GuestResponse response = new GuestResponse(
+                    session.isGuestApproval() ? "" : session.getId(),
+                    session.getTitle(),
+                    session.isGuestApproval(),
+                    session.getGuestApprovalRoomId().toString(),
+                    UUID.randomUUID().toString()
+            );
             return ResponseEntity.ok(response);
         }
         throw new SessionClosedException();

--- a/backend/src/main/java/c/team/session/controller/SessionManagerController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionManagerController.java
@@ -27,7 +27,11 @@ public class SessionManagerController {
                 request.getSessionTitle(),
                 request.isGuestApproval()
         );
-        SessionCreateResponse response = new SessionCreateResponse(session.getId(), session.getPasscode().toString());
+        SessionCreateResponse response = new SessionCreateResponse(
+                session.getId(),
+                session.getPasscode().toString(),
+                session.getGuestApprovalRoomId().toString()
+        );
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/c/team/session/controller/SessionManagerController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionManagerController.java
@@ -77,6 +77,6 @@ public class SessionManagerController {
     // Duplicate from UserAccountController, probably a universal exception handler can be created
     @ExceptionHandler(UsernameNotFoundException.class)
     public final ResponseEntity<Error> handleException(UsernameNotFoundException ex){
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 }

--- a/backend/src/main/java/c/team/session/exception/SessionNotOwnedException.java
+++ b/backend/src/main/java/c/team/session/exception/SessionNotOwnedException.java
@@ -1,0 +1,4 @@
+package c.team.session.exception;
+
+public class SessionNotOwnedException extends RuntimeException {
+}

--- a/backend/src/main/java/c/team/session/model/GuestResponse.java
+++ b/backend/src/main/java/c/team/session/model/GuestResponse.java
@@ -8,4 +8,7 @@ import lombok.Data;
 public class GuestResponse {
     String sessionId;
     String sessionTitle;
+    boolean guestApproval;
+    String guestApprovalRoomId;
+    String guestId;
 }

--- a/backend/src/main/java/c/team/session/model/Session.java
+++ b/backend/src/main/java/c/team/session/model/Session.java
@@ -20,6 +20,8 @@ public class Session {
     private String leaderAccountId;
     private UUID passcode;
     private boolean active;
+    private boolean guestApproval;
+    private UUID guestApprovalRoomId;
     private List<Message> log;
     private Set<Guest> guests;
 }

--- a/backend/src/main/java/c/team/session/model/SessionCreateRequest.java
+++ b/backend/src/main/java/c/team/session/model/SessionCreateRequest.java
@@ -15,4 +15,8 @@ public class SessionCreateRequest {
     @NotBlank
     @Parameter(required = true)
     private String sessionTitle;
+
+    @NotBlank
+    @Parameter(required = true)
+    private boolean guestApproval;
 }

--- a/backend/src/main/java/c/team/session/model/SessionCreateResponse.java
+++ b/backend/src/main/java/c/team/session/model/SessionCreateResponse.java
@@ -8,4 +8,5 @@ import lombok.Data;
 public class SessionCreateResponse {
     String sessionId;
     String passcode;
+    String approvalRoomId;
 }

--- a/requests/session-create.http
+++ b/requests/session-create.http
@@ -3,7 +3,8 @@ Content-Type: application/json
 
 {
   "username": "username",
-  "sessionTitle": "sessionTitle"
+  "sessionTitle": "sessionTitle",
+  "guestApproval": false
 }
 
 ###


### PR DESCRIPTION
Dodałem zatwierdzanie guestów - dodaje to dodatkowe endpointy, nowe kody błędów w przypadku zamykania sesji przez innego użytkownika jest UNAUTHORIZED, w przypadku zamykania kontem, które nie istnieje jest NO_CONTENT. Dodatkowo zmiany w postaci requesta na tworzenie sesji oraz responsa na stworzenie sesji oraz responsa na dołączanie guesta do sesji (uwzględnia teraz możliwości potrzeby bycia zatwierdzonym przez właściciela sesji). Kwestia zatwierdzania guestów została dorzucona do README backendu. Samo zatwierdzanie nie było testowane - jest ono zrobione na websocketach i potrzebny frontend do tego.