### PR TITLE
[Hotfix] Wrong guest ID - participant list request

### DIFF
--- a/backend/src/main/java/c/team/message/model/Message.java
+++ b/backend/src/main/java/c/team/message/model/Message.java
@@ -12,5 +12,5 @@ public class Message {
     private MessageType type;
     private String timestamp;
     private String sessionId;
-    private String content; // TODO:  Change to Content class when implementing quizzes, etc.
+    private Object content; // TODO:  Change to Content class when implementing quizzes, etc.
 }

--- a/backend/src/main/java/c/team/participants/list/ParticipantListRequest.java
+++ b/backend/src/main/java/c/team/participants/list/ParticipantListRequest.java
@@ -8,8 +8,9 @@ import javax.validation.constraints.NotBlank;
 @Data
 public class ParticipantListRequest {
     // Only one at the time is used
-    private String guestId;
-    private String accountUsername;
+    @NotBlank
+    @Parameter(required = true)
+    private String identification;  // account username of owner or guestId
 
     @NotBlank
     @Parameter(required = true)

--- a/backend/src/main/java/c/team/session/SessionRepository.java
+++ b/backend/src/main/java/c/team/session/SessionRepository.java
@@ -3,9 +3,11 @@ package c.team.session;
 import c.team.session.model.Session;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface SessionRepository extends MongoRepository<Session, UUID> {
     Session findSessionByPasscode(UUID passcode);
     Session findSessionById(String id);
+    Optional<Session> findSessionByGuestApprovalRoomId(UUID guestApprovalRoomId);
 }

--- a/backend/src/main/java/c/team/session/SessionService.java
+++ b/backend/src/main/java/c/team/session/SessionService.java
@@ -64,14 +64,17 @@ public class SessionService {
         sessionRepository.save(session);
     }
 
-    public void addGuestToSession(String sessionId, String guestName){
+    public String addGuestToSession(String sessionId, String guestName){
         Session session = this.findBySessionId(sessionId);
+        String guestId = UUID.randomUUID().toString();
         Guest guest = Guest.builder()
-                .id(UUID.randomUUID().toString())
+                .id(guestId)
                 .username(guestName)
+                .approved(false)
                 .build();
         session.getGuests().put(guest.getId(), guest);
         sessionRepository.save(session);
+        return guestId;
     }
 
     public void removeGuestFromSession(String sessionId, String guestId){

--- a/backend/src/main/java/c/team/session/SessionService.java
+++ b/backend/src/main/java/c/team/session/SessionService.java
@@ -99,4 +99,9 @@ public class SessionService {
         return Optional.ofNullable(sessionRepository.findSessionById(sessionsId))
                 .orElseThrow(() -> new SessionNotFoundException("no sessions with id: " + sessionsId));
     }
+
+    public Session findByGuestApprovalRoomId(UUID guestApprovalRoomId){
+        return sessionRepository.findSessionByGuestApprovalRoomId(guestApprovalRoomId)
+                .orElseThrow(() -> new SessionNotFoundException("no session with approval room: " + guestApprovalRoomId));
+    }
 }

--- a/backend/src/main/java/c/team/session/controller/SessionController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionController.java
@@ -4,6 +4,7 @@ import c.team.message.exception.InvalidMessageTypeException;
 import c.team.message.model.Message;
 import c.team.message.model.MessageType;
 import c.team.session.SessionService;
+import c.team.session.model.Session;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -37,8 +38,9 @@ public class SessionController {
         if(message.getType() != MessageType.CONNECT)
             throw new InvalidMessageTypeException();
         headerAccessor.getSessionAttributes().put("guestId", message.getSender());
-        headerAccessor.getSessionAttributes().put("sessionId", message.getSessionId());
-        sessionsService.addGuestToSession(message.getSessionId(), message.getSender());
+        headerAccessor.getSessionAttributes().put("sessionId", sessionId);
+        Session session = sessionsService.findBySessionId(sessionId);
+        session.getGuests().get(message.getSender()).setApproved(true);
         return message;
     }
 

--- a/backend/src/main/java/c/team/session/controller/SessionController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionController.java
@@ -17,6 +17,8 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.UUID;
+
 @Controller
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class SessionController {
@@ -60,7 +62,14 @@ public class SessionController {
         if(message.getType() != MessageType.GUEST_APPROVAL)
             throw new InvalidMessageTypeException();
         // TODO: If session leader rejects - delete from session guests
-        return message;
+        Message updatedResponse = Message.builder()
+                .sender(message.getSender())
+                .timestamp(message.getTimestamp())
+                .content(message.getContent())
+                .sessionId((boolean) message.getContent() ? sessionsService.findByGuestApprovalRoomId(  // this can explode
+                        UUID.fromString(sessionApprovalId)).getId() : "")
+                .build();
+        return updatedResponse;
     }
 
     @ExceptionHandler(InvalidMessageTypeException.class)

--- a/backend/src/main/java/c/team/session/controller/SessionController.java
+++ b/backend/src/main/java/c/team/session/controller/SessionController.java
@@ -59,6 +59,7 @@ public class SessionController {
     public Message guestApprovalResponse(@DestinationVariable String sessionApprovalId, @DestinationVariable String guestId, @Payload final Message message){
         if(message.getType() != MessageType.GUEST_APPROVAL)
             throw new InvalidMessageTypeException();
+        // TODO: If session leader rejects - delete from session guests
         return message;
     }
 

--- a/backend/src/main/java/c/team/session/model/Guest.java
+++ b/backend/src/main/java/c/team/session/model/Guest.java
@@ -8,4 +8,5 @@ import lombok.Data;
 public class Guest {
     private String id;
     private String username;
+    private boolean approved;
 }

--- a/requests/session-participant-list.http
+++ b/requests/session-participant-list.http
@@ -2,8 +2,7 @@ POST http://localhost:8080/session/participant-list
 Content-Type: application/json
 
 {
-  "guestId": "guestId",
-  "accountUsername": "accountUsername",
+  "identification": "guestId or account_username"
   "sessionId": "sessionId"
 }
 


### PR DESCRIPTION
Naprawiłem problem, przez który guest wysyłał niezgodne swoje ID z tym co jest zapisane w sesji. Dodatkowo, request o listę ma teraz tylko jedno pole - identification (albo guestId albo username konta).