### PR TITLE
Hotfix odbierania odpowiedzi na backendzie

### DIFF
--- a/backend/src/main/java/c/team/quiz/model/Answer.java
+++ b/backend/src/main/java/c/team/quiz/model/Answer.java
@@ -11,4 +11,8 @@ public class Answer {
     private String text;
     @Parameter(required = true)
     private boolean correct;
+
+    public Answer(String text){
+        this.text = text;
+    }
 }

--- a/backend/src/main/java/c/team/quiz/model/QuizAnswers.java
+++ b/backend/src/main/java/c/team/quiz/model/QuizAnswers.java
@@ -1,5 +1,6 @@
 package c.team.quiz.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Map;
 // Can be used as 'content' field of message
 // Sent by guests only (in QUIZ_ANSWERS message)
 @Getter
+@AllArgsConstructor
 public class QuizAnswers {
     private Map<String, List<Answer>> quizAnswers;
 }

--- a/backend/src/main/java/c/team/session/administration/controller/SessionController.java
+++ b/backend/src/main/java/c/team/session/administration/controller/SessionController.java
@@ -103,7 +103,7 @@ public class SessionController {
             throw new InvalidMessageTypeException();
         sessionsService.addMessageToSessionLog(sessionId, message);
 
-        QuizAnswers answersToQuestions = (QuizAnswers) message.getContent();
+        QuizAnswers answersToQuestions = answersService.convertMapToQuizAnswers((Map<String, List<String>>) message.getContent());
         answersToQuestions.getQuizAnswers().forEach( (questionId, answers) -> {
             List<Integer> answerIdx = answersService.getAnswerCountsOrAddForQuestion(questionId, answers);
             answersService.addAnswers(sessionId, questionId, answerIdx);

--- a/backend/src/main/java/c/team/session/statistics/SessionAnswersService.java
+++ b/backend/src/main/java/c/team/session/statistics/SessionAnswersService.java
@@ -7,19 +7,22 @@ import c.team.quiz.exception.QuizNotFoundException;
 import c.team.quiz.model.Answer;
 import c.team.quiz.model.Question;
 import c.team.quiz.model.Quiz;
+import c.team.quiz.model.QuizAnswers;
 import c.team.session.statistics.model.SessionAnswers;
 import c.team.session.statistics.model.SessionAnswersDto;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Service
 @AllArgsConstructor
-// A tu nie powinno być autowire?
+// A tu nie powinno być autowire???
 public class SessionAnswersService {
 
     private final QuestionRepository questionRepository;
@@ -60,5 +63,20 @@ public class SessionAnswersService {
                     questionRepository.save(question);
                 });
         return answerIdx;
+    }
+
+    public QuizAnswers convertMapToQuizAnswers(Map<String, List<String>> rawData) {
+        Map<String, List<Answer>> quizAnswers = new HashMap<>();
+        rawData.forEach((questionId, answersToQuestion) ->
+                quizAnswers.put(
+                        questionId,
+                        answersToQuestion.stream().map(content ->  {
+                            Answer answer = new Answer();
+                            answer.setText(content);
+                            return answer;
+                            }).collect(Collectors.toList())
+                )
+        );
+        return new QuizAnswers(quizAnswers);
     }
 }

--- a/backend/src/main/java/c/team/session/statistics/SessionAnswersService.java
+++ b/backend/src/main/java/c/team/session/statistics/SessionAnswersService.java
@@ -22,7 +22,6 @@ import java.util.stream.IntStream;
 
 @Service
 @AllArgsConstructor
-// A tu nie powinno być autowire???
 public class SessionAnswersService {
 
     private final QuestionRepository questionRepository;
@@ -66,17 +65,15 @@ public class SessionAnswersService {
     }
 
     public QuizAnswers convertMapToQuizAnswers(Map<String, List<String>> rawData) {
-        Map<String, List<Answer>> quizAnswers = new HashMap<>();
-        rawData.forEach((questionId, answersToQuestion) ->
-                quizAnswers.put(
-                        questionId,
-                        answersToQuestion.stream().map(content ->  {
-                            Answer answer = new Answer();
-                            answer.setText(content);
-                            return answer;
-                            }).collect(Collectors.toList())
-                )
-        );
-        return new QuizAnswers(quizAnswers);
+        Map<String, List<Answer>> answers = rawData
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        e-> e.getValue()
+                                .stream()
+                                .map(Answer::new)
+                                .collect(Collectors.toList()
+                                )));
+        return new QuizAnswers(answers);
     }
 }


### PR DESCRIPTION
Wcześniej był problem, bo próbowałem castować mapę na klasę - teraz parsuję tą mapę, aby stworzyć klasę.
Ważne jest, by odpowiedzi dalej były wysyłane jako mapy: {question_id: lista_odpowiedzi}, także dla pytań otwartych (question_id i odpowiedzi na pytania to stringi).