### PR TITLE
bugfix/renamed_statistics_endpoint

### DIFF
--- a/backend/src/main/java/c/team/session/statistics/SessionAnswersController.java
+++ b/backend/src/main/java/c/team/session/statistics/SessionAnswersController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/session/{sessionId}/statistics/answers")
+@RequestMapping("/temporary/{sessionId}/statistics/answers")
 @AllArgsConstructor
 public class SessionAnswersController {
     private final SessionService sessionService;


### PR DESCRIPTION
zmieniona nazwa \
`/session/{sessionId}/statistics/answers` -> `/temporary/{sessionId}/statistics/answers`