### PR TITLE
Hotfix for quizzes and answers on frontend

### DIFF
--- a/backend/src/main/java/c/team/quiz/model/Question.java
+++ b/backend/src/main/java/c/team/quiz/model/Question.java
@@ -25,6 +25,8 @@ public class Question {
     @Parameter(required = true)
     @NotBlank
     private String content;
+    @Parameter(required = true)
+    private boolean open;
     @Valid
     @Nullable
     private List<Answer> answers;
@@ -33,6 +35,7 @@ public class Question {
         return QuestionDto.builder()
                 .answers(answers)
                 .content(content)
+                .open(open)
                 .id(id)
                 .build();
     }

--- a/backend/src/main/java/c/team/quiz/model/QuestionDto.java
+++ b/backend/src/main/java/c/team/quiz/model/QuestionDto.java
@@ -22,6 +22,8 @@ public class QuestionDto {
     @Parameter(required = true)
     @NotBlank
     private String content;
+    @Parameter(required = true)
+    private boolean open;
     @Valid
     @Nullable
     private List<Answer> answers;
@@ -30,6 +32,7 @@ public class QuestionDto {
         return Question.builder()
                 .id(id)
                 .quizId(quizId)
+                .open(open)
                 .answers(answers)
                 .content(content)
                 .build();

--- a/backend/src/main/java/c/team/session/administration/controller/SessionController.java
+++ b/backend/src/main/java/c/team/session/administration/controller/SessionController.java
@@ -100,13 +100,15 @@ public class SessionController {
     // Might require additional security
     @MessageMapping("/socket/session/{sessionId}/quiz-answers")    // Here participants send quiz answers
     @SendTo("/topic/session/{sessionId}/quiz-answers")      // Here leader subscribes to receive quiz answers
-    public Message sendQuizAnswersToLeader(@DestinationVariable String sessionId, @Payload final Message message) throws JsonProcessingException {
+    public Message sendQuizAnswersToLeader(@DestinationVariable String sessionId,
+                                           @Payload final Message message) throws JsonProcessingException {
         if (message.getType() != MessageType.QUIZ_ANSWERS)
             throw new InvalidMessageTypeException();
         sessionsService.addMessageToSessionLog(sessionId, message);
 
-        QuizAnswers answersToQuestions = answersService.convertMapToQuizAnswers(objectMapper.readValue(message.getContent(), new TypeReference<>() {
-        }));
+        QuizAnswers answersToQuestions = answersService.convertMapToQuizAnswers(
+                objectMapper.readValue(message.getContent(), new TypeReference<>() {}));
+
         answersToQuestions.getQuizAnswers().forEach((questionId, answers) -> {
             List<Integer> answerIdx = answersService.getAnswerCountsOrAddForQuestion(questionId, answers);
             answersService.addAnswers(sessionId, questionId, answerIdx);

--- a/backend/src/main/java/c/team/session/statistics/SessionAnswersService.java
+++ b/backend/src/main/java/c/team/session/statistics/SessionAnswersService.java
@@ -64,6 +64,7 @@ public class SessionAnswersService {
         return answerIdx;
     }
 
+    // questionId -> answers
     public QuizAnswers convertMapToQuizAnswers(Map<String, List<String>> rawData) {
         Map<String, List<Answer>> answers = rawData
                 .entrySet()

--- a/frontend/io-webapp/src/presession/Designer.js
+++ b/frontend/io-webapp/src/presession/Designer.js
@@ -9,7 +9,7 @@ import "./designer.css";
 const Designer = ({ state, dispatch }) => {
   const createHandler = (e) => {
     e.preventDefault();
-
+    console.log(state.designerQuestions);
     (async () => {
       await fetch(process.env.REACT_APP_BACKEND_URL + "/quiz", {
         method: "POST",
@@ -34,6 +34,7 @@ const Designer = ({ state, dispatch }) => {
 
   const editHandler = (e) => {
     e.preventDefault();
+    console.log(state.designerQuestions);
     (async () => {
       await fetch(process.env.REACT_APP_BACKEND_URL + `/quiz/${state.quizId}`, {
         method: "PUT",

--- a/frontend/io-webapp/src/presession/Designer.js
+++ b/frontend/io-webapp/src/presession/Designer.js
@@ -9,6 +9,7 @@ import "./designer.css";
 const Designer = ({ state, dispatch }) => {
   const createHandler = (e) => {
     e.preventDefault();
+
     (async () => {
       await fetch(process.env.REACT_APP_BACKEND_URL + "/quiz", {
         method: "POST",
@@ -33,6 +34,7 @@ const Designer = ({ state, dispatch }) => {
 
   const editHandler = (e) => {
     e.preventDefault();
+
     (async () => {
       await fetch(process.env.REACT_APP_BACKEND_URL + `/quiz/${state.quizId}`, {
         method: "PUT",

--- a/frontend/io-webapp/src/presession/Designer.js
+++ b/frontend/io-webapp/src/presession/Designer.js
@@ -9,7 +9,6 @@ import "./designer.css";
 const Designer = ({ state, dispatch }) => {
   const createHandler = (e) => {
     e.preventDefault();
-    console.log(state.designerQuestions);
     (async () => {
       await fetch(process.env.REACT_APP_BACKEND_URL + "/quiz", {
         method: "POST",
@@ -34,7 +33,6 @@ const Designer = ({ state, dispatch }) => {
 
   const editHandler = (e) => {
     e.preventDefault();
-    console.log(state.designerQuestions);
     (async () => {
       await fetch(process.env.REACT_APP_BACKEND_URL + `/quiz/${state.quizId}`, {
         method: "PUT",

--- a/frontend/io-webapp/src/presession/QuestionList.js
+++ b/frontend/io-webapp/src/presession/QuestionList.js
@@ -37,7 +37,7 @@ const QuestionList = ({ state, dispatch }) => {
       >
         <div className="questionListElementInfo">
           <div style={{fontSize: "16px", fontWeight: "bold"}}>{question.content}</div>
-          <div style={{fontSize: "11px"}}>Type: {question.answers.length > 1 ? "ABCD" : "Open"}</div>
+          <div style={{fontSize: "11px"}}>Type: {question.open ? "Open" : "ABCD"}</div>
         </div>
         <div className="questionListElementButtons">
           <FiTrash2

--- a/frontend/io-webapp/src/reducer.js
+++ b/frontend/io-webapp/src/reducer.js
@@ -151,7 +151,6 @@ export const reducer = (state, action) => {
       return { ...state, isStatsVisible: false };
 
     case "ADD_DESIGNER_QUESTION":
-      console.log(action.payload);
       return {
         ...state,
         designerQuestions: [...state.designerQuestions, action.payload],
@@ -163,7 +162,6 @@ export const reducer = (state, action) => {
     case "SET_QUIZ_EDIT_MODE":
       return { ...state, editMode: action.payload };
     case "UPDATE_DESIGNER_QUESTION":
-      console.log(action.payload);
       return {
         ...state,
         designerQuestions: [
@@ -202,7 +200,6 @@ export const reducer = (state, action) => {
       };
 
     case "SET_QUIZ_LIST":
-      console.log(action.payload);
       return { ...state, quizList: action.payload };
 
     case "SET_QUIZ_NAME":

--- a/frontend/io-webapp/src/reducer.js
+++ b/frontend/io-webapp/src/reducer.js
@@ -151,6 +151,7 @@ export const reducer = (state, action) => {
       return { ...state, isStatsVisible: false };
 
     case "ADD_DESIGNER_QUESTION":
+      console.log(action.payload);
       return {
         ...state,
         designerQuestions: [...state.designerQuestions, action.payload],
@@ -162,6 +163,7 @@ export const reducer = (state, action) => {
     case "SET_QUIZ_EDIT_MODE":
       return { ...state, editMode: action.payload };
     case "UPDATE_DESIGNER_QUESTION":
+      console.log(action.payload);
       return {
         ...state,
         designerQuestions: [
@@ -200,6 +202,7 @@ export const reducer = (state, action) => {
       };
 
     case "SET_QUIZ_LIST":
+      console.log(action.payload);
       return { ...state, quizList: action.payload };
 
     case "SET_QUIZ_NAME":

--- a/frontend/io-webapp/src/session/Creator.js
+++ b/frontend/io-webapp/src/session/Creator.js
@@ -16,6 +16,7 @@ const Creator = ({ state, dispatch, close }) => {
 
     if (question !== "") {
       const newQuestion = state.stage === "designer" ? {content: question} : { question: question };
+      newQuestion.open = !abcd;
       if (answer !== "") {
         newQuestion.answers = state.stage === "designer" ? [{ text: answer, correct: true }] : { answers : [answer] };
       } else if (
@@ -60,6 +61,9 @@ const Creator = ({ state, dispatch, close }) => {
   };
 
   React.useEffect(() => {
+    console.log(state.designerQuestions[state.pickedQuestion]);
+    if (state.designerQuestions[state.pickedQuestion])
+      console.log(!state.designerQuestions[state.pickedQuestion].open);
     if (state.stage === "designer") {
       if (state.pickedQuestion < 0) {
         setQuestion("");
@@ -75,7 +79,7 @@ const Creator = ({ state, dispatch, close }) => {
           setAnswers(["", "", "", ""]);
           setCorrects([false, false, false, false]);
         } else if (
-          state.designerQuestions[state.pickedQuestion].answers.length > 1
+          !state.designerQuestions[state.pickedQuestion].open
         ) {
           setAbcd(true);
           setAnswers([

--- a/frontend/io-webapp/src/session/Creator.js
+++ b/frontend/io-webapp/src/session/Creator.js
@@ -61,9 +61,6 @@ const Creator = ({ state, dispatch, close }) => {
   };
 
   React.useEffect(() => {
-    console.log(state.designerQuestions[state.pickedQuestion]);
-    if (state.designerQuestions[state.pickedQuestion])
-      console.log(!state.designerQuestions[state.pickedQuestion].open);
     if (state.stage === "designer") {
       if (state.pickedQuestion < 0) {
         setQuestion("");

--- a/frontend/io-webapp/src/session/Question.js
+++ b/frontend/io-webapp/src/session/Question.js
@@ -27,7 +27,6 @@ const Question = ({ state, dispatch }) => {
       type: "quiz-answers",
       content: answers,
     };
-    console.log(msg);
     state.socket.sendMessage(msg);
     updateQuestions();
   };
@@ -53,7 +52,7 @@ const Question = ({ state, dispatch }) => {
     const { value } = e.target;
     setAnswer(value);
   };
-  console.log(current);
+
   return (
     <div className="question" style={{ width: state.questionWidth }}>
       {state.awaitsApproval ? (

--- a/frontend/io-webapp/src/session/Question.js
+++ b/frontend/io-webapp/src/session/Question.js
@@ -2,13 +2,12 @@ import React from "react";
 
 const Question = ({ state, dispatch }) => { 
   const [questions, setQuestions] = React.useState([]);
-  const [current, setCurrent] = React.useState(questions[0]);
+  const [current, setCurrent] = React.useState(undefined);
 
   const [answer, setAnswer] = React.useState("");
 
   const updateQuestions = () => {
-    let shift = true;
-    if (questions.length == 0) shift = false;
+    let shift = questions.length !== 0;
     let newQuestions = questions;
     if (state.socket) {
       console.log(state)
@@ -28,6 +27,7 @@ const Question = ({ state, dispatch }) => {
       type: "quiz-answers",
       content: answers,
     };
+    console.log(msg);
     state.socket.sendMessage(msg);
     updateQuestions();
   };
@@ -53,22 +53,22 @@ const Question = ({ state, dispatch }) => {
     const { value } = e.target;
     setAnswer(value);
   };
-
+  console.log(current);
   return (
     <div className="question" style={{ width: state.questionWidth }}>
       {state.awaitsApproval ? (
         <h1>Waiting for permission from room owner</h1>
-      ) : questions.length ? (
-        current.answers.length > 1 ? (
+      ) : current ? (
+        !current.open ? (
           <div key={current.id} className="specificQuestion">
-            <h1 className="questionProper">{current.question}</h1>
+            <h1 className="questionProper">{current.content}</h1>
             <div className="questionRow">
               <div
                 className="answer"
                 onClick={(e) => submitHandler(current.id, 0)}
               >
                 <h4>A:</h4>
-                <p style={{ textIndent: "3px" }}>{current.answers[0]}</p>
+                <p style={{ textIndent: "3px" }}>{current.answers[0].text}</p>
               </div>
             </div>
             <div className="questionRow">
@@ -77,7 +77,7 @@ const Question = ({ state, dispatch }) => {
                 onClick={(e) => submitHandler(current.id, 1)}
               >
                 <h4>B:</h4>
-                <p style={{ textIndent: "3px" }}>{current.answers[1]}</p>
+                <p style={{ textIndent: "3px" }}>{current.answers[1].text}</p>
               </div>
             </div>
             <div className="questionRow">
@@ -86,7 +86,7 @@ const Question = ({ state, dispatch }) => {
                 onClick={(e) => submitHandler(current.id, 2)}
               >
                 <h4>C:</h4>
-                <p style={{ textIndent: "3px" }}>{current.answers[2]}</p>
+                <p style={{ textIndent: "3px" }}>{current.answers[2].text}</p>
               </div>
             </div>
             <div className="questionRow">
@@ -95,13 +95,13 @@ const Question = ({ state, dispatch }) => {
                 onClick={(e) => submitHandler(current.id, 3)}
               >
                 <h4>D:</h4>
-                <p style={{ textIndent: "3px" }}>{current.answers[3]}</p>
+                <p style={{ textIndent: "3px" }}>{current.answers[3].text}</p>
               </div>
             </div>
           </div>
         ) : (
           <div key={current.id} className="specificQuestion">
-            <h1 className="questionProper">{current.question}</h1>
+            <h1 className="questionProper">{current.content}</h1>
             <div className="questionRow">
               <form
                 className="answer"

--- a/frontend/io-webapp/src/session/QuestionPicker.js
+++ b/frontend/io-webapp/src/session/QuestionPicker.js
@@ -16,16 +16,6 @@ const QuestionPicker = ({ state, dispatch }) => {
       content: quiz
     }
     state.socket.sendMessage(msg);
-    // for (let i = 0; i < quiz.questions.length; i++) {
-    //   const q = quiz.questions[i];
-    //   const newQuestion = { question: q.content };
-    //   newQuestion.answers = { answers : q.answers.map((a) => {return a.text}) };
-    //   const msg = {
-    //     type : "quiz",
-    //     content: newQuestion,
-    //   };
-    //   state.socket.sendMessage(msg);
-    // }
   };
 
   React.useEffect(() => {
@@ -44,7 +34,6 @@ const QuestionPicker = ({ state, dispatch }) => {
         .catch((error) => {
           console.error(error);
         });
-      console.log(state.quizList);
     })();
   }, []);
 

--- a/frontend/io-webapp/src/session/QuestionPicker.js
+++ b/frontend/io-webapp/src/session/QuestionPicker.js
@@ -11,16 +11,21 @@ const QuestionPicker = ({ state, dispatch }) => {
   const submitHandler = (e, quiz) => {
     e.preventDefault();
 
-    for (let i = 0; i < quiz.questions.length; i++) {
-      const q = quiz.questions[i];
-      const newQuestion = { question: q.content };
-      newQuestion.answers = { answers : q.answers.map((a) => {return a.text}) };
-      const msg = {
-        type : "quiz",
-        content: newQuestion, 
-      };
-      state.socket.sendMessage(msg);
+    const msg = {
+      type: "quiz",
+      content: quiz
     }
+    state.socket.sendMessage(msg);
+    // for (let i = 0; i < quiz.questions.length; i++) {
+    //   const q = quiz.questions[i];
+    //   const newQuestion = { question: q.content };
+    //   newQuestion.answers = { answers : q.answers.map((a) => {return a.text}) };
+    //   const msg = {
+    //     type : "quiz",
+    //     content: newQuestion,
+    //   };
+    //   state.socket.sendMessage(msg);
+    // }
   };
 
   React.useEffect(() => {
@@ -39,6 +44,7 @@ const QuestionPicker = ({ state, dispatch }) => {
         .catch((error) => {
           console.error(error);
         });
+      console.log(state.quizList);
     })();
   }, []);
 

--- a/frontend/io-webapp/src/socket.js
+++ b/frontend/io-webapp/src/socket.js
@@ -160,17 +160,13 @@ class Socket {
     const message = JSON.parse(payload.body);
 
     if (message.type === "CONNECT") {
-      console.log(message);
+      console.log(message);   // consider deleting
     } else if (message.type === "DISCONNECT") {
-      console.log(message);
+      console.log(message);   // consider deleting
     } else {
-      console.log(message);
       if(message.type === 'QUIZ'){
         const quiz = JSON.parse(message.content);
-        console.log(quiz);
-        console.log(quiz.id);
         this.quizId = quiz.id;
-        console.log(quiz.questions);
         this.questions.push.apply(this.questions, quiz.questions);
       }
       if(message.type === "COMMENT"){
@@ -178,7 +174,7 @@ class Socket {
           listener(message);
         }
       }
-      
+
 
       // messageElement.classList.add('chat-message')
 

--- a/frontend/io-webapp/src/socket.js
+++ b/frontend/io-webapp/src/socket.js
@@ -19,6 +19,7 @@ class Socket {
     this.isLeader = isLeader;
     this.messageListeners = [];
     this.questions = []
+    this.quizId = ""
   }
 
   addMessageListener(listener) {
@@ -117,6 +118,7 @@ class Socket {
         timestamp: moment().calendar(),
       };
       console.log(messageToSend);
+      console.log("JSON: " + JSON.stringify(messageToSend));
       this.stompClient.send(
           `/app/socket/session/${this.state.sessionId}/${message.type}`,
           {},
@@ -162,19 +164,19 @@ class Socket {
     } else if (message.type === "DISCONNECT") {
       console.log(message);
     } else {
+      console.log(message);
       if(message.type === 'QUIZ'){
-        const content = JSON.parse(message.content);
-        let question = {
-          question : content.question,
-          answers : content.answers.answers,
-          id : message.id
-        };
-        this.questions.push(question);
+        const quiz = JSON.parse(message.content);
+        console.log(quiz);
+        console.log(quiz.id);
+        this.quizId = quiz.id;
+        console.log(quiz.questions);
+        this.questions.push.apply(this.questions, quiz.questions);
       }
       if(message.type === "COMMENT"){
         for (const listener of this.messageListeners) {
-        listener(message);
-      }
+          listener(message);
+        }
       }
       
 

--- a/frontend/io-webapp/src/socket.js
+++ b/frontend/io-webapp/src/socket.js
@@ -118,7 +118,6 @@ class Socket {
         timestamp: moment().calendar(),
       };
       console.log(messageToSend);
-      console.log("JSON: " + JSON.stringify(messageToSend));
       this.stompClient.send(
           `/app/socket/session/${this.state.sessionId}/${message.type}`,
           {},
@@ -174,7 +173,6 @@ class Socket {
           listener(message);
         }
       }
-
 
       // messageElement.classList.add('chat-message')
 


### PR DESCRIPTION
Dostosowałem frontend do mechanizmów działania na backendzie. Teraz quizy są wysyłane jako jedna wiadomość, dodatkowo pytanie dostało nowy atrybut - 'open' (informuje, czy pytanie jest otwarte). Wysyłane odpowiedzi wygląda, że są zapisywane do bazy (baza widzi odpowiedzi, natomiast póki nie trzeba będzie ich wyjąć to ciężko stwierdzić, czy działa to w 100% poprawnie). 

Fun fact: w React setCurrent (czy inne settery) są asynchroniczne, więc część problemów była związana z tym, że po wywołaniu setCurrent parametr current dalej nie był ustawiony (dopiero w kolejnym renderze jest ustawiany, m.in. dlatego, że jest zadeklarowany jako const), ale finalnie udało mi się to obejść (przy pomocy undefined, nie jest to najpiękniejsze ale działa).